### PR TITLE
solve autoprefixer warning

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^13.2.0",
                 "@testing-library/user-event": "^13.5.0",
+                "autoprefixer": "10.4.5",
                 "bootstrap": "^5.1.3",
                 "bootstrap-icons": "^1.8.1",
                 "react": "^18.1.0",
@@ -4530,9 +4531,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.7",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
-            "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+            "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4544,8 +4545,8 @@
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.20.3",
-                "caniuse-lite": "^1.0.30001335",
+                "browserslist": "^4.20.2",
+                "caniuse-lite": "^1.0.30001332",
                 "fraction.js": "^4.2.0",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
@@ -12995,6 +12996,38 @@
                 "postcss": "^8.4"
             }
         },
+        "node_modules/postcss-preset-env/node_modules/autoprefixer": {
+            "version": "10.4.7",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
+            "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                }
+            ],
+            "dependencies": {
+                "browserslist": "^4.20.3",
+                "caniuse-lite": "^1.0.30001335",
+                "fraction.js": "^4.2.0",
+                "normalize-range": "^0.1.2",
+                "picocolors": "^1.0.0",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "bin": {
+                "autoprefixer": "bin/autoprefixer"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
         "node_modules/postcss-pseudo-class-any-link": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.2.tgz",
@@ -19665,12 +19698,12 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "autoprefixer": {
-            "version": "10.4.7",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
-            "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+            "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
             "requires": {
-                "browserslist": "^4.20.3",
-                "caniuse-lite": "^1.0.30001335",
+                "browserslist": "^4.20.2",
+                "caniuse-lite": "^1.0.30001332",
                 "fraction.js": "^4.2.0",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
@@ -25656,6 +25689,21 @@
                 "postcss-replace-overflow-wrap": "^4.0.0",
                 "postcss-selector-not": "^5.0.0",
                 "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "autoprefixer": {
+                    "version": "10.4.7",
+                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
+                    "integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+                    "requires": {
+                        "browserslist": "^4.20.3",
+                        "caniuse-lite": "^1.0.30001335",
+                        "fraction.js": "^4.2.0",
+                        "normalize-range": "^0.1.2",
+                        "picocolors": "^1.0.0",
+                        "postcss-value-parser": "^4.2.0"
+                    }
+                }
             }
         },
         "postcss-pseudo-class-any-link": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
         "@testing-library/user-event": "^13.5.0",
+        "autoprefixer": "10.4.5",
         "bootstrap": "^5.1.3",
         "bootstrap-icons": "^1.8.1",
         "react": "^18.1.0",


### PR DESCRIPTION
Warning
(6:29521) autoprefixer: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.

is a bootstrap problem and will be solved with the next bootstrap version.

fixed with older version of autoprefixer through: ```npm install autoprefixer@10.4.5 --save-exact```

